### PR TITLE
fixed inference error without loading int8 model

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -154,7 +154,6 @@ def load_data(args) -> list:
     Returns:
 
     """
-    file_path = f'dataset/{args.dataset}/test.json'
     if not os.path.exists(file_path):
         raise FileNotFoundError(f"can not find dataset file : {file_path}")
     json_data = json.load(open(file_path, 'r'))

--- a/evaluate.py
+++ b/evaluate.py
@@ -9,6 +9,7 @@ import fire
 
 import torch
 
+sys.path.append(os.path.join(os.getcwd(), "peft/src/"))
 from peft import PeftModel
 from transformers import GenerationConfig, LlamaForCausalLM, LlamaTokenizer, AutoModelForCausalLM, AutoTokenizer
 
@@ -169,6 +170,7 @@ def parse_args():
                         required=True)
     parser.add_argument('--base_model', required=True)
     parser.add_argument('--lora_weights', required=True)
+    parser.add_argument('--load_8bit', action='store_true', default=False)
 
     return parser.parse_args()
 
@@ -189,7 +191,7 @@ def load_model(args) -> tuple:
     if not lora_weights:
         raise ValueError(f'can not find lora weight, the value is: {lora_weights}')
 
-    load_8bit = True
+    load_8bit = args.load_8bit
     if args.model == 'LLaMA-7B':
         tokenizer = LlamaTokenizer.from_pretrained(base_model)
     else: 

--- a/evaluate.py
+++ b/evaluate.py
@@ -9,7 +9,6 @@ import fire
 
 import torch
 
-sys.path.append(os.path.join(os.getcwd(), "peft/src/"))
 from peft import PeftModel
 from transformers import GenerationConfig, LlamaForCausalLM, LlamaTokenizer, AutoModelForCausalLM, AutoTokenizer
 
@@ -154,6 +153,7 @@ def load_data(args) -> list:
     Returns:
 
     """
+    file_path = f'dataset/{args.dataset}/test.json'
     if not os.path.exists(file_path):
         raise FileNotFoundError(f"can not find dataset file : {file_path}")
     json_data = json.load(open(file_path, 'r'))

--- a/peft/src/peft/peft_model.py
+++ b/peft/src/peft/peft_model.py
@@ -84,6 +84,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             self.modules_to_save = self.peft_config.modules_to_save
             _set_trainable(self)
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.base_model_torch_dtype = getattr(model, "dtype", None)
 
     def save_pretrained(self, save_directory, **kwargs):
         r"""
@@ -615,6 +616,21 @@ class PeftModelForCausalLM(PeftModel):
         model_kwargs = self.base_model_prepare_inputs_for_generation(*args, **kwargs)
         if isinstance(self.peft_config, PromptLearningConfig):
             if model_kwargs["past_key_values"] is None and self.peft_config.peft_type == PeftType.PREFIX_TUNING:
+                if self.base_model_torch_dtype is not None:
+                    # handle the case for Bloom where it outputs tuple of tuples
+                    if isinstance(past_key_values[0], tuple):
+                        past_key_values = tuple(
+                            tuple(
+                                past_key_value.to(self.base_model_torch_dtype)
+                                for past_key_value in past_key_value_tuple
+                            )
+                            for past_key_value_tuple in past_key_values
+                        )
+                    else:
+                        past_key_values = tuple(
+                            past_key_value.to(self.base_model_torch_dtype) for past_key_value in past_key_values
+                        )
+                        
                 past_key_values = self.get_prompt(batch_size=model_kwargs["input_ids"].shape[0])
                 model_kwargs["past_key_values"] = past_key_values
             else:


### PR DESCRIPTION
During inference, if we don't load the INT8 model, there will be an error RuntimeError: expected scalar type Half but found Float for both bottleneck and LoRA adapters. This PR fixed the error.

LLaMA, GPT-j, and BLOOM are tested.