### PR TITLE
support ChatGLM

### DIFF
--- a/peft/src/peft/mapping.py
+++ b/peft/src/peft/mapping.py
@@ -66,6 +66,7 @@ TRANSFORMERS_MODELS_TO_BOTTLENECK_TARGET_MODULES_MAPPING = {
     "gpt_neo": ["c_fc", "c_proj"],
     "llama": ["gate_proj", "up_proj", "down_proj"],
     "opt": ["fc1", "fc2"],
+    "chatglm": ["dense_h_to_4h", "dense_4h_to_h"],
 }
 
 TRANSFORMERS_MODELS_TO_ADAPTERP_TARGET_MODULES_MAPPING = {
@@ -74,6 +75,7 @@ TRANSFORMERS_MODELS_TO_ADAPTERP_TARGET_MODULES_MAPPING = {
     "gpt_neo": ["c_proj"],
     "llama": ["down_proj"],
     "opt": ["fc2"],
+    "chatglm": ["dense_4h_to_h"],
 }
 
 TRANSFORMERS_MODELS_TO_PARALLEL_TARGET_MODULES_MAPPING = {
@@ -82,7 +84,7 @@ TRANSFORMERS_MODELS_TO_PARALLEL_TARGET_MODULES_MAPPING = {
     "gpt_neo": ["q_proj", "v_proj", "k_proj"],
     "llama": ["q_proj", "v_proj", "k_proj"],
     "opt": ["q_proj", "v_proj", "k_proj"],
-
+    "chatglm": ["query_key_value"],
 }
 
 

--- a/peft/src/peft/tuners/bottleneck.py
+++ b/peft/src/peft/tuners/bottleneck.py
@@ -20,6 +20,7 @@ TRANSFORMERS_MODELS_TO_ADAPTER_TYPE_MAPPING = {
     "gpt_neo": {"c_fc":"mh_adapter", "c_proj":"output_adapter"},
     "llama": {"gate_proj": "mh_adapter", "up_proj":"mh_adapter", "down_proj":"output_adapter"},
     "opt": {"fc1":"mh_adapter", "fc2":"output_adapter"},
+    "chatglm": {"dense_h_to_4h": "mh_adapter", "dense_4h_to_h": "output_adapter"},
 }
 
 def is_bnb_available():


### PR DESCRIPTION
ChatGLM is supported by this PR.

CUDA_VISIBLE_DEVICES=1 python finetune.py \
  --base_model 'THUDM/chatglm-6b' \
  --data_path 'math_data.json' \
  --output_dir './trained_models/chatglm_test' \
  --batch_size 16 \
  --micro_batch_size 4 \
  --num_epochs 3 \
  --learning_rate 3e-4 \
  --cutoff_len 256 \
  --val_set_size 120 \
  --adapter_name lora \
  --use_gradient_checkpointing 

This should work fine for fintuning.